### PR TITLE
feat: custom networks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn test
 yarn lint-staged

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": [
+    "chainlist"
+  ]
 }

--- a/common/custom-networks.ts
+++ b/common/custom-networks.ts
@@ -1,0 +1,12 @@
+/**
+ * Custom Networks have the top priority
+ *
+ * means CUSTOM_NETWORKS and default config the same `chainId` will use the CUSTOM one merge into the default one.
+ */
+export const CUSTOM_NETWORKS: Array<AtLeastOne<Chain, 'chainId'>> = [
+  {
+    name: 'Ethereum Mainnet test',
+    chainId: 1,
+    shortName: 'eth',
+  },
+]

--- a/common/custom-networks.ts
+++ b/common/custom-networks.ts
@@ -3,10 +3,10 @@
  *
  * means CUSTOM_NETWORKS and default config the same `chainId` will use the CUSTOM one merge into the default one.
  */
-export const CUSTOM_NETWORKS: Array<AtLeastOne<Chain, 'chainId'>> = [
+export const CUSTOM_NETWORKS: Array<AtLeastOne<Chain, 'chainId' | 'name'>> = [
   {
-    name: 'Ethereum Mainnet test',
-    chainId: 1,
-    shortName: 'eth',
+    chainId: 137,
+    name: 'Matic Mainnet',
+    rpc: ['https://matic-mainnet.chainstacklabs.com'],
   },
 ]

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -1,3 +1,6 @@
-export const env = {
-  isDAppBrowser: Boolean(window.ethereum),
+export const mergeNetworkConfig = (
+  initial: Chain[],
+  custom: Array<AtLeastOne<Chain, 'chainId'>>,
+): Chain[] => {
+  return Object.assign(initial, custom)
 }

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -2,5 +2,11 @@ export const mergeNetworkConfig = (
   initial: Chain[],
   custom: Array<AtLeastOne<Chain, 'chainId'>>,
 ): Chain[] => {
-  return Object.assign(initial, custom)
+  return initial.map(item => {
+    const customItem = custom.find(c => c.chainId === item.chainId)
+
+    if (customItem) return Object.assign({}, item, customItem)
+
+    return item
+  })
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -12,3 +12,5 @@ declare namespace NodeJS {
     NEXT_PUBLIC_SUPABASE_ANON_KEY: string
   }
 }
+
+type AtLeastOne<T, U extends keyof T> = Partial<T> & Required<Pick<T, U>>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/node": "12.0.12",
     "@types/react": "^16",
     "@types/react-dom": "^16",
-    "colors": "^1.4.0",
     "eslint": "^7.23.0",
     "husky": "^6.0.0",
     "lint-staged": ">=10",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "12.0.12",
     "@types/react": "^16",
     "@types/react-dom": "^16",
+    "colors": "^1.4.0",
     "eslint": "^7.23.0",
     "husky": "^6.0.0",
     "lint-staged": ">=10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "release": "standard-version --no-verify",
     "start": "next start",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "tsc -p tsconfig.test.json"
   },
   "author": "izayl@163.com",
   "dependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,12 @@ import { FormEventHandler, useState } from 'react'
 import debounce from 'lodash/debounce'
 import { orderBy } from 'lodash'
 import { GithubCorner, ChainItem } from '../common/components'
-import { getNetworkRecords, getOriginChains } from '../common/services'
-
+import {
+  getNetworkRecords,
+  getOriginChains,
+} from '../common/services'
+import { CUSTOM_NETWORKS } from '../common/custom-networks'
+import { mergeNetworkConfig } from '../common/utils'
 interface HomeProps {
   chains: Chain[]
 }
@@ -76,10 +80,14 @@ export default Home
 
 export const getStaticProps: GetStaticProps<HomeProps> = async() => {
   try {
-    const [chains, counts] = await Promise.all([
+    const [originChains, counts] = await Promise.all([
       getOriginChains(),
       getNetworkRecords(),
     ])
+
+    const chains = mergeNetworkConfig(originChains, CUSTOM_NETWORKS)
+
+    console.log({ chains })
 
     chains.forEach((chain: Chain) => {
       if (counts[chain.chainId]) chain.selectCounts = counts[chain.chainId]

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,10 +5,7 @@ import { FormEventHandler, useState } from 'react'
 import debounce from 'lodash/debounce'
 import { orderBy } from 'lodash'
 import { GithubCorner, ChainItem } from '../common/components'
-import {
-  getNetworkRecords,
-  getOriginChains,
-} from '../common/services'
+import { getNetworkRecords, getOriginChains } from '../common/services'
 import { CUSTOM_NETWORKS } from '../common/custom-networks'
 import { mergeNetworkConfig } from '../common/utils'
 interface HomeProps {
@@ -86,8 +83,6 @@ export const getStaticProps: GetStaticProps<HomeProps> = async() => {
     ])
 
     const chains = mergeNetworkConfig(originChains, CUSTOM_NETWORKS)
-
-    console.log({ chains })
 
     chains.forEach((chain: Chain) => {
       if (counts[chain.chainId]) chain.selectCounts = counts[chain.chainId]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -18,8 +18,9 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "noEmitOnError": true
   },
   "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "chainlist.d.ts", "**/*.ts", "**/*.tsx"]
+  "include": ["next-env.d.ts", "chainlist.d.ts", "common/custom-networks.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,6 +1261,11 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,11 +1261,6 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"


### PR DESCRIPTION
Add custom network to create high priority config especially `rpc` config, for network reason.

Custom Network is not necessary, but only when default rpc breakdown temporary.

Custom Network should not be a long time solution, if rpc break-down for long-term, it should be chagne at [repo](https://github.com/ethereum-lists/chains)